### PR TITLE
Fixes #27655 - Change cpu to cpu cores

### DIFF
--- a/lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb
+++ b/lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb
@@ -9,7 +9,7 @@ module HammerCLIForemanKubevirt
 
       def compute_attributes
         [
-          ['cores', _('number of cores, Integer value')],
+          ['cpu_cores', _('number of cores, Integer value')],
           ['memory', _('Amount of memory, integer value in bytes')]
         ]
       end


### PR DESCRIPTION
- The correct way to send the cpu attribute is cpu_cores.