### PR TITLE
Fixes #29497 - Add Internationalization support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,3 +42,9 @@ end
 task :default do
   Rake::Task['rubocop'].execute
 end
+
+require "hammer_cli_foreman_kubevirt/version"
+require "hammer_cli_foreman_kubevirt/i18n"
+require "hammer_cli/i18n/find_task"
+HammerCLI::I18n::FindTask.define(HammerCLIForemanKubevirt::I18n::LocaleDomain.new, HammerCLIForemanKubevirt.version)
+

--- a/lib/hammer_cli_foreman_kubevirt/i18n.rb
+++ b/lib/hammer_cli_foreman_kubevirt/i18n.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'hammer_cli/i18n'
+module HammerCLIForemanKubevirt
+  module I18n
+    class LocaleDomain < HammerCLI::I18n::LocaleDomain
+      def translated_files
+        Dir.glob(File.join(File.dirname(__FILE__), '../**/*.rb'))
+      end
+
+      def locale_dir
+        File.join(File.dirname(__FILE__), '../../locale')
+      end
+
+      def domain_name
+        'hammer-cli-foreman-kubevirt'
+      end
+
+      def type
+        :mo
+      end
+    end
+  end
+end
+
+HammerCLI::I18n.add_domain(HammerCLIForemanKubevirt::I18n::LocaleDomain.new)

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -1,0 +1,5 @@
+DOMAIN = hammer-cli-foreman-kubevirt
+VERSION = $(shell bundle exec ruby -C ../ -e 'require "rubygems"; spec = Gem::Specification::load("../hammer_cli_foreman_kubevirt.gemspec"); puts spec.version')
+MAIN_MAKEFILE = $(shell bundle exec ruby -C ../ -e 'require "hammer_cli"; puts HammerCLI::I18n.main_makefile')
+
+include $(MAIN_MAKEFILE)

--- a/locale/en/hammer-cli-foreman-kubevirt.edit.po
+++ b/locale/en/hammer-cli-foreman-kubevirt.edit.po
@@ -1,0 +1,67 @@
+# English translations for hammer-cli-foreman-kubevirt package.
+# Copyright (C) 2020 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the hammer-cli-foreman-kubevirt package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-foreman-kubevirt 0.1.4\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-04-07 17:30+0530\n"
+"PO-Revision-Date: 2020-04-07 17:30+0530\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:7
+msgid "KubeVirt"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:12
+msgid "number of cores, Integer value"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:13
+msgid "Amount of memory, integer value in bytes"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:19
+msgid "Boolean (expressed as 0 or 1), whether to start the machine or not"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:25
+msgid "Container Network Interface Provider name"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:26
+msgid "The network to connect the vm to"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:32
+msgid "Volume size in GB, integer value"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:33
+msgid "Name of the storage class"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:34
+msgid "Boolean, only one volume can be bootable (overrides network interface boot)"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:40
+msgid "hostname"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:41
+msgid "api_port"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:42
+msgid "namespace"
+msgstr ""

--- a/locale/en/hammer-cli-foreman-kubevirt.po
+++ b/locale/en/hammer-cli-foreman-kubevirt.po
@@ -1,0 +1,54 @@
+# English translations for hammer-cli-foreman-kubevirt package.
+# Copyright (C) 2020 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the hammer-cli-foreman-kubevirt package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-foreman-kubevirt 0.1.4\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2020-04-07 17:30+0530\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+msgid "KubeVirt"
+msgstr ""
+
+msgid "number of cores, Integer value"
+msgstr ""
+
+msgid "Amount of memory, integer value in bytes"
+msgstr ""
+
+msgid "Boolean (expressed as 0 or 1), whether to start the machine or not"
+msgstr ""
+
+msgid "Container Network Interface Provider name"
+msgstr ""
+
+msgid "The network to connect the vm to"
+msgstr ""
+
+msgid "Volume size in GB, integer value"
+msgstr ""
+
+msgid "Name of the storage class"
+msgstr ""
+
+msgid "Boolean, only one volume can be bootable (overrides network interface boot)"
+msgstr ""
+
+msgid "hostname"
+msgstr ""
+
+msgid "api_port"
+msgstr ""
+
+msgid "namespace"
+msgstr ""

--- a/locale/hammer-cli-foreman-kubevirt.pot
+++ b/locale/hammer-cli-foreman-kubevirt.pot
@@ -1,0 +1,67 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the hammer-cli-foreman-kubevirt package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-foreman-kubevirt 0.1.4\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-04-07 17:30+0530\n"
+"PO-Revision-Date: 2020-04-07 17:30+0530\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:7
+msgid "KubeVirt"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:12
+msgid "number of cores, Integer value"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:13
+msgid "Amount of memory, integer value in bytes"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:19
+msgid "Boolean (expressed as 0 or 1), whether to start the machine or not"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:25
+msgid "Container Network Interface Provider name"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:26
+msgid "The network to connect the vm to"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:32
+msgid "Volume size in GB, integer value"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:33
+msgid "Name of the storage class"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:34
+msgid "Boolean, only one volume can be bootable (overrides network interface boot)"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:40
+msgid "hostname"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:41
+msgid "api_port"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb:42
+msgid "namespace"
+msgstr ""


### PR DESCRIPTION
Adding Internationalization support for kubevirt. This basically extends the hammer-cli i18n implementation and so below commands are available,
~~~
# rake gettext:find - Update pot file
# make all-mo (default) - generate MO files
# make check - check translations using translate-tool
# make tx-update - download and merge translations from Transifex
# make clean - clean everything
~~~
