### PR TITLE
Make gettext a development dependency

### DIFF
--- a/hammer_cli_foreman_kubevirt.gemspec
+++ b/hammer_cli_foreman_kubevirt.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib,config}/**/*', 'LICENSE', 'README*']
   s.require_paths = ["lib"]
 
-  s.add_dependency 'gettext', '>= 3.1.3', '< 4.0.0'
   s.add_dependency 'hammer_cli_foreman', '>=0.17.0'
+  s.add_development_dependency 'gettext', '>= 3.1.3', '< 4.0.0'
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rubocop', '~> 0.64'
 end


### PR DESCRIPTION
It is needed to extract locales, but at runtime hammer-cli already provides `_()` via `fast_gettext`.

Similar to https://github.com/theforeman/hammer-cli-foreman-kubevirt/pull/20.