### PR TITLE
Use theforeman-rubocop gem

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,4 +14,6 @@ jobs:
   rubocop:
     name: Rubocop
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+    with:
+      command: bundle exec rubocop --parallel --format github
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,61 +1,9 @@
-require:
-  - rubocop-performance
-  - rubocop-minitest
+inherit_gem:
+  theforeman-rubocop:
+    - strictest.yml
 
 AllCops:
-  NewCops: enable
-
-Layout/LineLength:
-  Enabled: false
+  TargetRubyVersion: 2.7
 
 Metrics:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Gemspec/RequireMFA:
-  Enabled: false
-
-Style/SymbolProc:
-  Enabled: false
-
-Style/IfUnlessModifier:
-  Enabled: false
-
-Style/ConditionalAssignment:
-  Enabled: false
-
-Style/EmptyMethod:
-  EnforcedStyle: expanded
-
-Style/ParenthesesAroundCondition:
-  Enabled: false
-
-Layout/HashAlignment:
-  Enabled: false
-
-Layout/ParameterAlignment:
-  Enabled: false
-
-# disabled until we can configure "+" as concat sign
-Style/LineEndConcatenation:
-  Enabled: false
-
-Style/ParallelAssignment:
-  Enabled: false
-
-Style/PreferredHashMethods:
-  Enabled: false
-
-Style/MultipleComparison:
-  Enabled: false
-
-Style/SymbolArray:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,9 @@
-source "https://rubygems.org"
-dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+dev_gemfile = File.expand_path('Gemfile.dev.rb', __dir__)
 eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 gemspec
 gem 'rake', '~> 10.1.0'
 
-group :rubocop do
-  gem 'rubocop-minitest', '~> 0.9.0'
-  gem 'rubocop-performance', '~> 1.5.2'
-  gem 'rubocop-rake', '~> 0.6.0'
-end
+gem 'theforeman-rubocop', '~> 0.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
+
 begin
   require 'bundler/setup'
 rescue LoadError
@@ -39,10 +41,10 @@ rescue LoadError
   task default: :test
 else
   RuboCop::RakeTask.new
-  task default: [:rubocop, :test]
+  task default: %i[rubocop test]
 end
 
-require "hammer_cli_foreman_kubevirt/version"
-require "hammer_cli_foreman_kubevirt/i18n"
-require "hammer_cli/i18n/find_task"
+require 'hammer_cli_foreman_kubevirt/version'
+require 'hammer_cli_foreman_kubevirt/i18n'
+require 'hammer_cli/i18n/find_task'
 HammerCLI::I18n::FindTask.define(HammerCLIForemanKubevirt::I18n::LocaleDomain.new, HammerCLIForemanKubevirt.version)

--- a/hammer_cli_foreman_kubevirt.gemspec
+++ b/hammer_cli_foreman_kubevirt.gemspec
@@ -1,17 +1,19 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require "hammer_cli_foreman_kubevirt/version"
+require 'hammer_cli_foreman_kubevirt/version'
 
 Gem::Specification.new do |s|
-  s.name = "hammer_cli_foreman_kubevirt"
-  s.authors = ["Shira Maximov"]
+  s.name = 'hammer_cli_foreman_kubevirt'
+  s.authors = ['Shira Maximov']
   s.homepage = 'https://github.com/theforeman/hammer-cli-foreman-kubevirt'
   s.version = HammerCLIForemanKubevirt.version.dup
   s.license = 'GPL-3.0'
   s.platform = Gem::Platform::RUBY
   s.summary = 'Foreman kubevirt commands for Hammer CLI'
   s.description = 'Foreman kubevirt commands for Hammer CLI.'
-  s.files = Dir['{lib,config,locale}/**/*', 'LICENSE', 'README*'] + Dir["locale/**/*.{po,pot,mo}"]
-  s.require_paths = ["lib"]
+  s.files = Dir['{lib,config,locale}/**/*', 'LICENSE', 'README*'] + Dir['locale/**/*.{po,pot,mo}']
+  s.require_paths = ['lib']
 
   s.add_dependency 'hammer_cli_foreman', '~> 3.10'
   s.required_ruby_version = '>= 2.7', '< 4'

--- a/lib/hammer_cli_foreman_kubevirt.rb
+++ b/lib/hammer_cli_foreman_kubevirt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HammerCLIForemanKubevirt
   require 'hammer_cli_foreman_kubevirt/compute_resources/kubevirt'
   require 'hammer_cli_foreman/compute_resource/register_compute_resources'

--- a/lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb
+++ b/lib/hammer_cli_foreman_kubevirt/compute_resources/kubevirt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'hammer_cli_foreman/compute_resource/base'
 
 module HammerCLIForemanKubevirt
@@ -10,20 +12,20 @@ module HammerCLIForemanKubevirt
       def compute_attributes
         [
           ['cpu_cores', _('number of cores, Integer value')],
-          ['memory', _('Amount of memory, integer value in bytes')]
+          ['memory', _('Amount of memory, integer value in bytes')],
         ]
       end
 
       def host_attributes
         [
-          ['start', _('Boolean (expressed as 0 or 1), whether to start the machine or not')]
+          ['start', _('Boolean (expressed as 0 or 1), whether to start the machine or not')],
         ]
       end
 
       def interface_attributes
         [
           ['compute_cni_provider', _('Container Network Interface Provider name')],
-          ['compute_network', _('The network to connect the vm to')]
+          ['compute_network', _('The network to connect the vm to')],
         ]
       end
 
@@ -31,7 +33,7 @@ module HammerCLIForemanKubevirt
         [
           ['capacity', _('Volume size in GB, integer value')],
           ['storage_class', _('Name of the storage class')],
-          ['bootable', _('Boolean, only one volume can be bootable (overrides network interface boot)')]
+          ['bootable', _('Boolean, only one volume can be bootable (overrides network interface boot)')],
         ]
       end
 
@@ -39,7 +41,7 @@ module HammerCLIForemanKubevirt
         [
           Fields::Field.new(label: _('hostname'), path: [:hostname]),
           Fields::Field.new(label: _('api_port'), path: [:api_port]),
-          Fields::Field.new(label: _('namespace'), path: [:namespace])
+          Fields::Field.new(label: _('namespace'), path: [:namespace]),
         ]
       end
 

--- a/lib/hammer_cli_foreman_kubevirt/version.rb
+++ b/lib/hammer_cli_foreman_kubevirt/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HammerCLIForemanKubevirt
   def self.version
     @version ||= Gem::Version.new '0.2.0'


### PR DESCRIPTION
Inherited strictest.yml here, this rules have NewCops enable config. Also dropped some cops from here because that was either included in the inherit file or was not needed anymore.

Also I fixed cops like Style/FrozenStringLiteralComment and Style/StringLiterals.

This is part of Rubocop standerdization, link for the reference:
https://community.theforeman.org/t/standardizing-rubocop-with-theforeman-rubocop/37239
https://github.com/theforeman/theforeman-rubocop/?tab=readme-ov-file#all-opinionated-cops-with-new-ones---strictest
